### PR TITLE
Add new dev image with packages to support cypress

### DIFF
--- a/dev/Dockerfile.slim.ruby-3.0.4
+++ b/dev/Dockerfile.slim.ruby-3.0.4
@@ -1,0 +1,27 @@
+FROM ruby:3.0.4-slim-buster
+
+RUN apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      libgtk2.0-0 \
+      libgtk-3-0 \
+      libgbm-dev \
+      libnotify-dev \
+      libgconf-2-4 \
+      libnss3 \
+      libxss1 \
+      libasound2 \
+      libxtst6 \
+      xauth \
+      xvfb \
+      curl \
+      imagemagick \
+      libpq-dev \
+    && apt-get remove python3 \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends ghostscript geoip-database shared-mime-info nodejs yarn \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt


### PR DESCRIPTION
Installs the needed libraries outlined in Cypress [documentation](https://docs.cypress.io/guides/getting-started/installing-cypress#Ubuntu-Debian) and adds it to a new `dev` image 🎉