### PR TITLE
chore: bump ruby version to 3.3.1

### DIFF
--- a/anony-base/Dockerfile-3.3.1
+++ b/anony-base/Dockerfile-3.3.1
@@ -1,0 +1,29 @@
+# This is a base image for a ruby app that also includes a local postgres server. Convenient for very few select use cases.
+FROM ruby:3.3.1-slim-bookworm
+
+WORKDIR /app
+
+RUN apt-get clean && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      build-essential \
+      curl \
+      git \ 
+      gnupg \
+      gpg \
+      gpg-agent \
+      libpq-dev \
+      sudo \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# Set-up to use a specific version of postgres
+COPY ./apt.postgresql.org.sh apt.postgresql.org.sh
+
+# Additional packages needed for compiling gems and supporting postgres server
+RUN bash apt.postgresql.org.sh -v 11 && \
+    apt-get update -q && \
+    apt-get install --assume-yes -q --no-install-recommends postgresql-client-11 postgresql-11
+
+# log the image build date
+RUN echo "anony-base="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/dx.sh
+++ b/dx.sh
@@ -13,14 +13,14 @@ function help () {
   echo "  images                    - list the available images"
   echo
   echo "example (test and release): "
-  echo "1. install latest packages for rails-run 3.3.0 image"
-  echo "   > freshen rails-run 3.3.0"
-  echo "2. after testing, promote latest image to new 3.3.0 tag"
-  echo "   > release rails-run 3.3.0"
+  echo "1. install latest packages for rails-run 3.3.1 image"
+  echo "   > freshen rails-run 3.3.1"
+  echo "2. after testing, promote latest image to new 3.3.1 tag"
+  echo "   > release rails-run 3.3.1"
   echo
   echo "example (full send): "
-  echo "1. build, tag and deploy an updated image rails-run 3.3.0 image"
-  echo "   > update rails-run 3.3.0"
+  echo "1. build, tag and deploy an updated image rails-run 3.3.1 image"
+  echo "   > update rails-run 3.3.1"
   echo
 }
 

--- a/rails-build/Dockerfile-3.3.1
+++ b/rails-build/Dockerfile-3.3.1
@@ -1,0 +1,15 @@
+FROM ruby:3.3.1-slim-bookworm
+
+RUN apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl build-essential git libpq-dev software-properties-common rsync \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-build/Dockerfile-3.3.1
+++ b/rails-build/Dockerfile-3.3.1
@@ -12,4 +12,4 @@ RUN apt-get update -q \
     && rm -fr /var/cache/apt
 
 # log the image build date
-RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY
+RUN echo "rails-build="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-run/Dockerfile-3.3.1
+++ b/rails-run/Dockerfile-3.3.1
@@ -1,0 +1,19 @@
+FROM ruby:3.3.1-slim-bookworm
+
+RUN apt-get clean && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl \
+      git \
+      imagemagick \
+      libpq-dev \
+    && apt-get remove python3 \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends ghostscript geoip-database shared-mime-info yarn nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY


### PR DESCRIPTION
This PR looks to introduce the newest Ruby version (3.3.1) to these images. Once merged, following the guidance of the `freshen` method in the `dx.sh` script, please push these updated images to the hub (krsyoung/rails-build, krsyoung/rails-run).