### PR TITLE
fix: include npm in images

### DIFF
--- a/rails-build/Dockerfile-3.3.1
+++ b/rails-build/Dockerfile-3.3.1
@@ -6,7 +6,7 @@ RUN apt-get update -q \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update -q \
-    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn nodejs \
+    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn nodejs npm \
     && apt-get autoremove --assume-yes \
     && rm -rf /var/lib/apt/lists \
     && rm -fr /var/cache/apt


### PR DESCRIPTION
I'm unsure why, but with the new 3.3.1 image came some difficulties around leveraging npm. Specifically we have a pipeline that runs based off of this image, and in previous versions worked without issue. After the update it seems we've lost access to npm, causing commands such as `vite:info` and `npx` to fail on execution.

This is the fix we've discovered works for us, but it feels more like a brute force approach without a good understanding of WHY npm started failing. Maybe someone else also has an opinion/theory for the 'why' this is happening.

Note that npm was never a required dependency in previous versions.