### PR TITLE
Update up to 3.3.4

### DIFF
--- a/dx.sh
+++ b/dx.sh
@@ -1,5 +1,5 @@
 # /bin/bash
-DOCKHER_HUB_ACCOUNT="krsyoung"
+DOCKER_HUB_ACCOUNT="krsyoung"
 
 function help () {
   echo "** rails build tooling **"
@@ -33,7 +33,7 @@ function images () {
 
 # login to docker
 function login () {
-  docker login --username=$DOCKHER_HUB_ACCOUNT
+  docker login --username=$DOCKER_HUB_ACCOUNT
 }
 
 # tag an exiting image as latest and push
@@ -46,7 +46,7 @@ function release () {
 
   # tag the specific version with latest  
   push $image $version
-  docker tag $DOCKHER_HUB_ACCOUNT/$image:$version $DOCKHER_HUB_ACCOUNT/$image:latest
+  docker tag $DOCKER_HUB_ACCOUNT/$image:$version $DOCKER_HUB_ACCOUNT/$image:latest
   push $image latest
 }
 
@@ -65,7 +65,7 @@ function build () {
   fi
 
   # build, without cache and apply a version tag based on the ruby version
-  docker build --no-cache -f $dockerfile -t $DOCKHER_HUB_ACCOUNT/$image:$version $image/
+  docker build --no-cache -f $dockerfile -t $DOCKER_HUB_ACCOUNT/$image:$version $image/
 }
 
 function push () {
@@ -75,7 +75,7 @@ function push () {
   [ -z "$version" ] && echo "Error: need an version." && return 1
 
   echo "Pushing $image:$version"
-  docker push "$DOCKHER_HUB_ACCOUNT/$image:$version"
+  docker push "$DOCKER_HUB_ACCOUNT/$image:$version"
 }
 
 # build image and tag with current date

--- a/rails-build/Dockerfile-3.3.2
+++ b/rails-build/Dockerfile-3.3.2
@@ -1,0 +1,15 @@
+FROM ruby:3.3.2-slim-bookworm
+
+RUN apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl build-essential git gpg libpq-dev software-properties-common rsync \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-build="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-build/Dockerfile-3.3.3
+++ b/rails-build/Dockerfile-3.3.3
@@ -1,0 +1,15 @@
+FROM ruby:3.3.3-slim-bookworm
+
+RUN apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl build-essential git gpg libpq-dev software-properties-common rsync \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-build="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-build/Dockerfile-3.3.4
+++ b/rails-build/Dockerfile-3.3.4
@@ -1,0 +1,15 @@
+FROM ruby:3.3.4-slim-bookworm
+
+RUN apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl build-essential git gpg libpq-dev software-properties-common rsync \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-build="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-run/Dockerfile-3.3.2
+++ b/rails-run/Dockerfile-3.3.2
@@ -1,0 +1,20 @@
+FROM ruby:3.3.2-slim-bookworm
+
+RUN apt-get clean && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl \
+      git \
+      gpg \
+      imagemagick \
+      libpq-dev \
+    && apt-get remove python3 \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends ghostscript geoip-database shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-run/Dockerfile-3.3.3
+++ b/rails-run/Dockerfile-3.3.3
@@ -1,0 +1,20 @@
+FROM ruby:3.3.3-slim-bookworm
+
+RUN apt-get clean && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl \
+      git \
+      gpg \
+      imagemagick \
+      libpq-dev \
+    && apt-get remove python3 \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends ghostscript geoip-database shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY

--- a/rails-run/Dockerfile-3.3.4
+++ b/rails-run/Dockerfile-3.3.4
@@ -1,0 +1,20 @@
+FROM ruby:3.3.4-slim-bookworm
+
+RUN apt-get clean && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends \
+      curl \
+      git \
+      gpg \
+      imagemagick \
+      libpq-dev \
+    && apt-get remove python3 \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update -q \
+    && apt-get install --assume-yes -q --no-install-recommends ghostscript geoip-database shared-mime-info yarn npm nodejs \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists \
+    && rm -fr /var/cache/apt
+
+# log the image build date
+RUN echo "rails-run="$(date +"%Y-%m-%d %H:%M %Z") >> /DOCKER_IMAGE_BUILD_HISTORY


### PR DESCRIPTION
This PR is for #50 

Changes include:
1. Wording fix in `dx.sh`
2. Images for Ruby 3.3.2
3. Images for Ruby 3.3.3
4. Images for Ruby 3.3.4

All images have been built using `build` and released to docker hub successfully.